### PR TITLE
Issue-3: Fix for Vfs2NioFileSystemProvider.newFileChannel, Vfs2NioFileSystem.iterator and BasePath.toUri

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright © 2018 - 2018 SSHTOOLS Limited (support@sshtools.com)
+    Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -237,7 +237,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-vfs2</artifactId>
-			<version>2.2</version>
+			<version>2.8.0</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
+    Copyright © 2018 - 2024 SSHTOOLS Limited (support@sshtools.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/main/java/com/sshtools/vfs2nio/ChannelUtils.java
+++ b/src/main/java/com/sshtools/vfs2nio/ChannelUtils.java
@@ -22,139 +22,139 @@ import java.nio.channels.SeekableByteChannel;
 import java.nio.channels.WritableByteChannel;
 
 public class ChannelUtils {
-	
-	/** Method akin to Apache IOUtils.readFully without sanity checking */
-	public static int readFully(ReadableByteChannel src, ByteBuffer dst) throws IOException {
-		int count = 0;
-		while (dst.remaining() > 0) {
-			int n = src.read(dst);
-			if (n < 0) {
-				break;
-			} else {
-				count += n;
-			}
-		}
 
-		return count;
-	}
+    /** Method akin to Apache IOUtils.readFully without sanity checking */
+    public static int readFully(ReadableByteChannel src, ByteBuffer dst) throws IOException {
+        int count = 0;
+        while (dst.remaining() > 0) {
+            int n = src.read(dst);
+            if (n < 0) {
+                break;
+            } else {
+                count += n;
+            }
+        }
 
-	public static int writeFully(WritableByteChannel tgt, ByteBuffer buffer) throws IOException {
-		int result = 0;
-		while (buffer.remaining() > 0) {
-			result += tgt.write(buffer);
-		}
-		return result;
-	}
+        return count;
+    }
 
-	public static int read(SeekableByteChannel src, ByteBuffer dst, long position) throws IOException {
-		long posBackup = src.position();
-		src.position(position);
+    public static int writeFully(WritableByteChannel tgt, ByteBuffer buffer) throws IOException {
+        int result = 0;
+        while (buffer.remaining() > 0) {
+            result += tgt.write(buffer);
+        }
+        return result;
+    }
 
-		int result = src.read(dst);
-		src.position(posBackup);
-		return result;
-	}
+    public static int read(SeekableByteChannel src, ByteBuffer dst, long position) throws IOException {
+        long posBackup = src.position();
+        src.position(position);
 
-	public static int write(SeekableByteChannel dst, ByteBuffer src, long position) throws IOException {
-		long posBackup = dst.position();
-		dst.position(position);
+        int result = src.read(dst);
+        src.position(posBackup);
+        return result;
+    }
 
-		int result = dst.write(src);
-		dst.position(posBackup);
-		return result;
-	}
-	
-	public static long transferTo(
-			SeekableByteChannel src,
-			long position,
-			long count,
-			WritableByteChannel
-			target,
-			int blockSize) throws IOException {
-		long posBackup = src.position();
+    public static int write(SeekableByteChannel dst, ByteBuffer src, long position) throws IOException {
+        long posBackup = dst.position();
+        dst.position(position);
 
-		src.position(position);
+        int result = dst.write(src);
+        dst.position(posBackup);
+        return result;
+    }
 
-		ByteBuffer buffer = ByteBuffer.allocate(blockSize);
-		long done = 0;
-		long remaining;
-		while ((remaining = count - done) > 0) {
-			buffer.position(0);
+    public static long transferTo(
+            SeekableByteChannel src,
+            long position,
+            long count,
+            WritableByteChannel
+            target,
+            int blockSize) throws IOException {
+        long posBackup = src.position();
 
-			int limit = remaining > blockSize ? blockSize : (int)remaining;
-			buffer.limit(limit);
+        src.position(position);
 
-			int n = readFully(src, buffer);
-			if (n == 0) {
-				break;
-			} else {
-				done += n;
-			}
+        ByteBuffer buffer = ByteBuffer.allocate(blockSize);
+        long done = 0;
+        long remaining;
+        while ((remaining = count - done) > 0) {
+            buffer.position(0);
 
-			buffer.position(0);
-			buffer.limit(n);
-			writeFully(target, buffer);
-		}
-		
-		src.position(posBackup);
-		
-		return done;
-	}
-	
-	public static long transferFrom(SeekableByteChannel dst, ReadableByteChannel src, long position, long count, int blockSize) throws IOException {
-		ByteBuffer buffer = ByteBuffer.allocate(blockSize);
+            int limit = remaining > blockSize ? blockSize : (int)remaining;
+            buffer.limit(limit);
 
-		long posBackup = dst.position();
-		dst.position(position);
+            int n = readFully(src, buffer);
+            if (n == 0) {
+                break;
+            } else {
+                done += n;
+            }
 
-		long done = 0;
-		long remaining;
-		while ((remaining = count - done) > 0) {
-			buffer.position(0);
-			
-			int limit = remaining > blockSize ? blockSize : (int)remaining;
-			buffer.limit(limit);
+            buffer.position(0);
+            buffer.limit(n);
+            writeFully(target, buffer);
+        }
 
-			int contentSize = readFully(src, buffer);
-			if (contentSize == 0) {
-				break;
-			}
-			done += contentSize;
-			
-			buffer.position(0);
-			buffer.limit(contentSize);
-			writeFully(dst, buffer);
-		}
+        src.position(posBackup);
 
-		dst.position(posBackup);
+        return done;
+    }
 
-		return done;
-	}
+    public static long transferFrom(SeekableByteChannel dst, ReadableByteChannel src, long position, long count, int blockSize) throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocate(blockSize);
 
-	public static long readScattered(ReadableByteChannel src, ByteBuffer[] dsts, int offset, int length) throws IOException {
-		long result = 0;
-		for (int i = offset; i < length; ++i) {
-			ByteBuffer dst = dsts[i];			
-			int n = readFully(src, dst);
-			if (n == 0) {
-				break;
-			}
-			result += n;
-		}
-		return result;
-	}
+        long posBackup = dst.position();
+        dst.position(position);
 
-	public static long writeScattered(WritableByteChannel dst, ByteBuffer[] srcs, int offset, int length) throws IOException {
-		long result = 0;
-		for (int i = offset; i < length; ++i) {
-			ByteBuffer src = srcs[i];			
-			int n = writeFully(dst, src);
-			if (n == 0) {
-				break;
-			}
-			result += n;
-		}
-		return result;
-	}
+        long done = 0;
+        long remaining;
+        while ((remaining = count - done) > 0) {
+            buffer.position(0);
+
+            int limit = remaining > blockSize ? blockSize : (int)remaining;
+            buffer.limit(limit);
+
+            int contentSize = readFully(src, buffer);
+            if (contentSize == 0) {
+                break;
+            }
+            done += contentSize;
+
+            buffer.position(0);
+            buffer.limit(contentSize);
+            writeFully(dst, buffer);
+        }
+
+        dst.position(posBackup);
+
+        return done;
+    }
+
+    public static long readScattered(ReadableByteChannel src, ByteBuffer[] dsts, int offset, int length) throws IOException {
+        long result = 0;
+        for (int i = offset; i < length; ++i) {
+            ByteBuffer dst = dsts[i];
+            int n = readFully(src, dst);
+            if (n == 0) {
+                break;
+            }
+            result += n;
+        }
+        return result;
+    }
+
+    public static long writeScattered(WritableByteChannel dst, ByteBuffer[] srcs, int offset, int length) throws IOException {
+        long result = 0;
+        for (int i = offset; i < length; ++i) {
+            ByteBuffer src = srcs[i];
+            int n = writeFully(dst, src);
+            if (n == 0) {
+                break;
+            }
+            result += n;
+        }
+        return result;
+    }
 
 }

--- a/src/main/java/com/sshtools/vfs2nio/ChannelUtils.java
+++ b/src/main/java/com/sshtools/vfs2nio/ChannelUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2024 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/sshtools/vfs2nio/ChannelUtils.java
+++ b/src/main/java/com/sshtools/vfs2nio/ChannelUtils.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.sshtools.vfs2nio;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+public class ChannelUtils {
+	
+	/** Method akin to Apache IOUtils.readFully without sanity checking */
+	public static int readFully(ReadableByteChannel src, ByteBuffer dst) throws IOException {
+		int count = 0;
+		while (dst.remaining() > 0) {
+			int n = src.read(dst);
+			if (n < 0) {
+				break;
+			} else {
+				count += n;
+			}
+		}
+
+		return count;
+	}
+
+	public static int writeFully(WritableByteChannel tgt, ByteBuffer buffer) throws IOException {
+		int result = 0;
+		while (buffer.remaining() > 0) {
+			result += tgt.write(buffer);
+		}
+		return result;
+	}
+
+	public static int read(SeekableByteChannel src, ByteBuffer dst, long position) throws IOException {
+		long posBackup = src.position();
+		src.position(position);
+
+		int result = src.read(dst);
+		src.position(posBackup);
+		return result;
+	}
+
+	public static int write(SeekableByteChannel dst, ByteBuffer src, long position) throws IOException {
+		long posBackup = dst.position();
+		dst.position(position);
+
+		int result = dst.write(src);
+		dst.position(posBackup);
+		return result;
+	}
+	
+	public static long transferTo(
+			SeekableByteChannel src,
+			long position,
+			long count,
+			WritableByteChannel
+			target,
+			int blockSize) throws IOException {
+		long posBackup = src.position();
+
+		src.position(position);
+
+		ByteBuffer buffer = ByteBuffer.allocate(blockSize);
+		long done = 0;
+		long remaining;
+		while ((remaining = count - done) > 0) {
+			buffer.position(0);
+
+			int limit = remaining > blockSize ? blockSize : (int)remaining;
+			buffer.limit(limit);
+
+			int n = readFully(src, buffer);
+			if (n == 0) {
+				break;
+			} else {
+				done += n;
+			}
+
+			buffer.position(0);
+			buffer.limit(n);
+			writeFully(target, buffer);
+		}
+		
+		src.position(posBackup);
+		
+		return done;
+	}
+	
+	public static long transferFrom(SeekableByteChannel dst, ReadableByteChannel src, long position, long count, int blockSize) throws IOException {
+		ByteBuffer buffer = ByteBuffer.allocate(blockSize);
+
+		long posBackup = dst.position();
+		dst.position(position);
+
+		long done = 0;
+		long remaining;
+		while ((remaining = count - done) > 0) {
+			buffer.position(0);
+			
+			int limit = remaining > blockSize ? blockSize : (int)remaining;
+			buffer.limit(limit);
+
+			int contentSize = readFully(src, buffer);
+			if (contentSize == 0) {
+				break;
+			}
+			done += contentSize;
+			
+			buffer.position(0);
+			buffer.limit(contentSize);
+			writeFully(dst, buffer);
+		}
+
+		dst.position(posBackup);
+
+		return done;
+	}
+
+	public static long readScattered(ReadableByteChannel src, ByteBuffer[] dsts, int offset, int length) throws IOException {
+		long result = 0;
+		for (int i = offset; i < length; ++i) {
+			ByteBuffer dst = dsts[i];			
+			int n = readFully(src, dst);
+			if (n == 0) {
+				break;
+			}
+			result += n;
+		}
+		return result;
+	}
+
+	public static long writeScattered(WritableByteChannel dst, ByteBuffer[] srcs, int offset, int length) throws IOException {
+		long result = 0;
+		for (int i = offset; i < length; ++i) {
+			ByteBuffer src = srcs[i];			
+			int n = writeFully(dst, src);
+			if (n == 0) {
+				break;
+			}
+			result += n;
+		}
+		return result;
+	}
+
+}

--- a/src/main/java/com/sshtools/vfs2nio/FileChannelFromSeekableByteChannelBase.java
+++ b/src/main/java/com/sshtools/vfs2nio/FileChannelFromSeekableByteChannelBase.java
@@ -25,96 +25,96 @@ import java.nio.channels.SeekableByteChannel;
 import java.nio.channels.WritableByteChannel;
 
 public abstract class FileChannelFromSeekableByteChannelBase
-	extends FileChannel
+    extends FileChannel
 {
-	protected abstract SeekableByteChannel getSeekableByteChannel();
-	protected abstract int getBlockSize();
+    protected abstract SeekableByteChannel getSeekableByteChannel();
+    protected abstract int getBlockSize();
 
-	@Override
-	public int read(ByteBuffer dst) throws IOException {
-		return getSeekableByteChannel().read(dst);
-	}
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        return getSeekableByteChannel().read(dst);
+    }
 
-	@Override
-	public long read(ByteBuffer[] dsts, int offset, int length) throws IOException {
-		return ChannelUtils.readScattered(getSeekableByteChannel(), dsts, offset, length);
-	}
+    @Override
+    public long read(ByteBuffer[] dsts, int offset, int length) throws IOException {
+        return ChannelUtils.readScattered(getSeekableByteChannel(), dsts, offset, length);
+    }
 
-	@Override
-	public int write(ByteBuffer src) throws IOException {
-		return getSeekableByteChannel().write(src);
-	}
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        return getSeekableByteChannel().write(src);
+    }
 
-	@Override
-	public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {		
-		return ChannelUtils.writeScattered(getSeekableByteChannel(), srcs, offset, length);
-	}
+    @Override
+    public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return ChannelUtils.writeScattered(getSeekableByteChannel(), srcs, offset, length);
+    }
 
-	@Override
-	public long position() throws IOException {
-		return getSeekableByteChannel().position();
-	}
+    @Override
+    public long position() throws IOException {
+        return getSeekableByteChannel().position();
+    }
 
-	@Override
-	public FileChannel position(long newPosition) throws IOException {
-		getSeekableByteChannel().position(newPosition);
-		return this;
-	}
+    @Override
+    public FileChannel position(long newPosition) throws IOException {
+        getSeekableByteChannel().position(newPosition);
+        return this;
+    }
 
-	@Override
-	public long size() throws IOException {
-		return getSeekableByteChannel().size();
-	}
+    @Override
+    public long size() throws IOException {
+        return getSeekableByteChannel().size();
+    }
 
-	@Override
-	public FileChannel truncate(long size) throws IOException {
-		getSeekableByteChannel().truncate(size);
-		return this;
-	}
+    @Override
+    public FileChannel truncate(long size) throws IOException {
+        getSeekableByteChannel().truncate(size);
+        return this;
+    }
 
-	@Override
-	public void force(boolean metaData) throws IOException {
-		// Silently ignored
-		// throw new UnsupportedOperationException();
-	}
+    @Override
+    public void force(boolean metaData) throws IOException {
+        // Silently ignored
+        // throw new UnsupportedOperationException();
+    }
 
-	@Override
-	public long transferTo(long position, long count, WritableByteChannel target) throws IOException {
-		return ChannelUtils.transferTo(getSeekableByteChannel(), position, count, target, getBlockSize());
-	}
+    @Override
+    public long transferTo(long position, long count, WritableByteChannel target) throws IOException {
+        return ChannelUtils.transferTo(getSeekableByteChannel(), position, count, target, getBlockSize());
+    }
 
-	@Override
-	public long transferFrom(ReadableByteChannel src, long position, long count) throws IOException {
-		return ChannelUtils.transferFrom(getSeekableByteChannel(), src, position, count, getBlockSize());
-	}
+    @Override
+    public long transferFrom(ReadableByteChannel src, long position, long count) throws IOException {
+        return ChannelUtils.transferFrom(getSeekableByteChannel(), src, position, count, getBlockSize());
+    }
 
-	@Override
-	public int read(ByteBuffer dst, long position) throws IOException {
-		return ChannelUtils.read(getSeekableByteChannel(), dst, position);
-	}
+    @Override
+    public int read(ByteBuffer dst, long position) throws IOException {
+        return ChannelUtils.read(getSeekableByteChannel(), dst, position);
+    }
 
-	@Override
-	public int write(ByteBuffer src, long position) throws IOException {
-		return ChannelUtils.write(getSeekableByteChannel(), src, position);
-	}
+    @Override
+    public int write(ByteBuffer src, long position) throws IOException {
+        return ChannelUtils.write(getSeekableByteChannel(), src, position);
+    }
 
-	@Override
-	public MappedByteBuffer map(MapMode mode, long position, long size) throws IOException {
-		throw new UnsupportedOperationException();
-	}
+    @Override
+    public MappedByteBuffer map(MapMode mode, long position, long size) throws IOException {
+        throw new UnsupportedOperationException();
+    }
 
-	@Override
-	public FileLock lock(long position, long size, boolean shared) throws IOException {
-		throw new UnsupportedOperationException();
-	}
+    @Override
+    public FileLock lock(long position, long size, boolean shared) throws IOException {
+        throw new UnsupportedOperationException();
+    }
 
-	@Override
-	public FileLock tryLock(long position, long size, boolean shared) throws IOException {
-		throw new UnsupportedOperationException();
-	}
+    @Override
+    public FileLock tryLock(long position, long size, boolean shared) throws IOException {
+        throw new UnsupportedOperationException();
+    }
 
-	@Override
-	protected void implCloseChannel() throws IOException {
-		getSeekableByteChannel().close();
-	}
+    @Override
+    protected void implCloseChannel() throws IOException {
+        getSeekableByteChannel().close();
+    }
 }

--- a/src/main/java/com/sshtools/vfs2nio/FileChannelFromSeekableByteChannelBase.java
+++ b/src/main/java/com/sshtools/vfs2nio/FileChannelFromSeekableByteChannelBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2024 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/sshtools/vfs2nio/FileChannelFromSeekableByteChannelBase.java
+++ b/src/main/java/com/sshtools/vfs2nio/FileChannelFromSeekableByteChannelBase.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.sshtools.vfs2nio;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+public abstract class FileChannelFromSeekableByteChannelBase
+	extends FileChannel
+{
+	protected abstract SeekableByteChannel getSeekableByteChannel();
+	protected abstract int getBlockSize();
+
+	@Override
+	public int read(ByteBuffer dst) throws IOException {
+		return getSeekableByteChannel().read(dst);
+	}
+
+	@Override
+	public long read(ByteBuffer[] dsts, int offset, int length) throws IOException {
+		return ChannelUtils.readScattered(getSeekableByteChannel(), dsts, offset, length);
+	}
+
+	@Override
+	public int write(ByteBuffer src) throws IOException {
+		return getSeekableByteChannel().write(src);
+	}
+
+	@Override
+	public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {		
+		return ChannelUtils.writeScattered(getSeekableByteChannel(), srcs, offset, length);
+	}
+
+	@Override
+	public long position() throws IOException {
+		return getSeekableByteChannel().position();
+	}
+
+	@Override
+	public FileChannel position(long newPosition) throws IOException {
+		getSeekableByteChannel().position(newPosition);
+		return this;
+	}
+
+	@Override
+	public long size() throws IOException {
+		return getSeekableByteChannel().size();
+	}
+
+	@Override
+	public FileChannel truncate(long size) throws IOException {
+		getSeekableByteChannel().truncate(size);
+		return this;
+	}
+
+	@Override
+	public void force(boolean metaData) throws IOException {
+		// Silently ignored
+		// throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public long transferTo(long position, long count, WritableByteChannel target) throws IOException {
+		return ChannelUtils.transferTo(getSeekableByteChannel(), position, count, target, getBlockSize());
+	}
+
+	@Override
+	public long transferFrom(ReadableByteChannel src, long position, long count) throws IOException {
+		return ChannelUtils.transferFrom(getSeekableByteChannel(), src, position, count, getBlockSize());
+	}
+
+	@Override
+	public int read(ByteBuffer dst, long position) throws IOException {
+		return ChannelUtils.read(getSeekableByteChannel(), dst, position);
+	}
+
+	@Override
+	public int write(ByteBuffer src, long position) throws IOException {
+		return ChannelUtils.write(getSeekableByteChannel(), src, position);
+	}
+
+	@Override
+	public MappedByteBuffer map(MapMode mode, long position, long size) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public FileLock lock(long position, long size, boolean shared) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public FileLock tryLock(long position, long size, boolean shared) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	protected void implCloseChannel() throws IOException {
+		getSeekableByteChannel().close();
+	}
+}

--- a/src/main/java/com/sshtools/vfs2nio/FileChannelFromSeekableByteChannelImpl.java
+++ b/src/main/java/com/sshtools/vfs2nio/FileChannelFromSeekableByteChannelImpl.java
@@ -18,31 +18,31 @@ package com.sshtools.vfs2nio;
 import java.nio.channels.SeekableByteChannel;
 
 public class FileChannelFromSeekableByteChannelImpl
-	extends FileChannelFromSeekableByteChannelBase
+    extends FileChannelFromSeekableByteChannelBase
 {
-	public static final int DEFAULT_BLOCK_SIZE = 4096;
-	
-	protected SeekableByteChannel delegate;
-	protected int blockSize;
+    public static final int DEFAULT_BLOCK_SIZE = 4096;
 
-	public FileChannelFromSeekableByteChannelImpl(SeekableByteChannel delegate) {
-		this(delegate, DEFAULT_BLOCK_SIZE);
-	}
+    protected SeekableByteChannel delegate;
+    protected int blockSize;
 
-	public FileChannelFromSeekableByteChannelImpl(SeekableByteChannel delegate, int blockSize) {
-		super();
-		this.delegate = delegate;
-		this.blockSize = blockSize;
-	}
+    public FileChannelFromSeekableByteChannelImpl(SeekableByteChannel delegate) {
+        this(delegate, DEFAULT_BLOCK_SIZE);
+    }
 
-	@Override
-	protected SeekableByteChannel getSeekableByteChannel() {
-		return delegate;
-	}
+    public FileChannelFromSeekableByteChannelImpl(SeekableByteChannel delegate, int blockSize) {
+        super();
+        this.delegate = delegate;
+        this.blockSize = blockSize;
+    }
 
-	@Override
-	protected int getBlockSize() {
-		return blockSize;
-	}
+    @Override
+    protected SeekableByteChannel getSeekableByteChannel() {
+        return delegate;
+    }
+
+    @Override
+    protected int getBlockSize() {
+        return blockSize;
+    }
 }
 

--- a/src/main/java/com/sshtools/vfs2nio/FileChannelFromSeekableByteChannelImpl.java
+++ b/src/main/java/com/sshtools/vfs2nio/FileChannelFromSeekableByteChannelImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2024 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/sshtools/vfs2nio/FileChannelFromSeekableByteChannelImpl.java
+++ b/src/main/java/com/sshtools/vfs2nio/FileChannelFromSeekableByteChannelImpl.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.sshtools.vfs2nio;
+
+import java.nio.channels.SeekableByteChannel;
+
+public class FileChannelFromSeekableByteChannelImpl
+	extends FileChannelFromSeekableByteChannelBase
+{
+	public static final int DEFAULT_BLOCK_SIZE = 4096;
+	
+	protected SeekableByteChannel delegate;
+	protected int blockSize;
+
+	public FileChannelFromSeekableByteChannelImpl(SeekableByteChannel delegate) {
+		this(delegate, DEFAULT_BLOCK_SIZE);
+	}
+
+	public FileChannelFromSeekableByteChannelImpl(SeekableByteChannel delegate, int blockSize) {
+		super();
+		this.delegate = delegate;
+		this.blockSize = blockSize;
+	}
+
+	@Override
+	protected SeekableByteChannel getSeekableByteChannel() {
+		return delegate;
+	}
+
+	@Override
+	protected int getBlockSize() {
+		return blockSize;
+	}
+}
+

--- a/src/main/java/com/sshtools/vfs2nio/Vfs2NioDirectoryStream.java
+++ b/src/main/java/com/sshtools/vfs2nio/Vfs2NioDirectoryStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2018 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/sshtools/vfs2nio/Vfs2NioDirectoryStream.java
+++ b/src/main/java/com/sshtools/vfs2nio/Vfs2NioDirectoryStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2024 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/sshtools/vfs2nio/Vfs2NioException.java
+++ b/src/main/java/com/sshtools/vfs2nio/Vfs2NioException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2018 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/sshtools/vfs2nio/Vfs2NioException.java
+++ b/src/main/java/com/sshtools/vfs2nio/Vfs2NioException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2024 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileAttributeView.java
+++ b/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileAttributeView.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2018 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileAttributeView.java
+++ b/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileAttributeView.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2024 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileAttributes.java
+++ b/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileAttributes.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2018 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileAttributes.java
+++ b/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileAttributes.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2024 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileStore.java
+++ b/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2018 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileStore.java
+++ b/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2024 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileSystem.java
+++ b/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileSystem.java
@@ -57,7 +57,7 @@ public class Vfs2NioFileSystem extends BaseFileSystem<Vfs2NioPath, Vfs2NioFileSy
 	public Vfs2NioFileAttributes getFileAttributes(Vfs2NioPath path) {
 		return new Vfs2NioFileAttributes(pathToFileObject(path));
 	}
-	
+
 	public URI getUri() {
 		return uri;
 	}
@@ -94,13 +94,13 @@ public class Vfs2NioFileSystem extends BaseFileSystem<Vfs2NioPath, Vfs2NioFileSy
 			return true;
 		}
 	}
-	
-	
+
+
 	public static String[] getPathSegments(Path path) {
 		int n = path.getNameCount();
-		
+
 		String[] result = new String[n];
-		
+
 		// The iterator is expected to yield n items
 		Iterator<Path> it = path.iterator();
 		for (int i = 0; i < n; ++i) {
@@ -114,7 +114,7 @@ public class Vfs2NioFileSystem extends BaseFileSystem<Vfs2NioPath, Vfs2NioFileSy
 	public Iterator<Path> iterator(Path path, Filter<? super Path> filter) throws IOException {
 		FileObject obj = pathToFileObject(Vfs2NioFileSystemProvider.toVFSPath(path));
 		FileObject[] children = obj.getChildren();
-		
+
 		String[] baseNames = getPathSegments(path);
 		int childNameIdx = baseNames.length;
 
@@ -129,15 +129,11 @@ public class Vfs2NioFileSystem extends BaseFileSystem<Vfs2NioPath, Vfs2NioFileSy
 			@Override
 			public Path next() {
 				Path croot = path.getRoot();
-//				Broken code:
-//				Path f = path.getFileName();
-//				return new Vfs2NioPath(Vfs2NioFileSystem.this, croot.toString(),
-//						(f == null ? "" : f.toString() + "/") + children[index++].getName().getBaseName().toString());
 
 				String[] childNames = Arrays.copyOf(baseNames, childNameIdx + 1);
 				childNames[childNameIdx] = children[index].getName().getBaseName().toString();
 				++index;
-				
+
 				return new Vfs2NioPath(Vfs2NioFileSystem.this, croot.toString(), childNames);
 			}
 		};

--- a/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileSystem.java
+++ b/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileSystem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2024 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileSystem.java
+++ b/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileSystem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2018 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,10 @@ public class Vfs2NioFileSystem extends BaseFileSystem<Vfs2NioPath, Vfs2NioFileSy
 	public Vfs2NioFileAttributes getFileAttributes(Vfs2NioPath path) {
 		return new Vfs2NioFileAttributes(pathToFileObject(path));
 	}
+	
+	public URI getUri() {
+		return uri;
+	}
 
 	public FileObject getRoot() {
 		return root;
@@ -90,10 +94,30 @@ public class Vfs2NioFileSystem extends BaseFileSystem<Vfs2NioPath, Vfs2NioFileSy
 			return true;
 		}
 	}
+	
+	
+	public static String[] getPathSegments(Path path) {
+		int n = path.getNameCount();
+		
+		String[] result = new String[n];
+		
+		// The iterator is expected to yield n items
+		Iterator<Path> it = path.iterator();
+		for (int i = 0; i < n; ++i) {
+			String segment = it.next().toString();
+			result[i] = segment;
+		}
+		return result;
+	}
+
 
 	public Iterator<Path> iterator(Path path, Filter<? super Path> filter) throws IOException {
 		FileObject obj = pathToFileObject(Vfs2NioFileSystemProvider.toVFSPath(path));
 		FileObject[] children = obj.getChildren();
+		
+		String[] baseNames = getPathSegments(path);
+		int childNameIdx = baseNames.length;
+
 		return new Iterator<Path>() {
 			int index;
 
@@ -105,9 +129,16 @@ public class Vfs2NioFileSystem extends BaseFileSystem<Vfs2NioPath, Vfs2NioFileSy
 			@Override
 			public Path next() {
 				Path croot = path.getRoot();
-				Path f = path.getFileName();
-				return new Vfs2NioPath(Vfs2NioFileSystem.this, croot.toString(),
-						(f == null ? "" : f.toString() + "/") + children[index++].getName().getBaseName().toString());
+//				Broken code:
+//				Path f = path.getFileName();
+//				return new Vfs2NioPath(Vfs2NioFileSystem.this, croot.toString(),
+//						(f == null ? "" : f.toString() + "/") + children[index++].getName().getBaseName().toString());
+
+				String[] childNames = Arrays.copyOf(baseNames, childNameIdx + 1);
+				childNames[childNameIdx] = children[index].getName().getBaseName().toString();
+				++index;
+				
+				return new Vfs2NioPath(Vfs2NioFileSystem.this, croot.toString(), childNames);
 			}
 		};
 	}

--- a/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileSystemProvider.java
+++ b/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileSystemProvider.java
@@ -81,11 +81,11 @@ public class Vfs2NioFileSystemProvider extends FileSystemProvider {
 	public void checkAccess(Path path, AccessMode... modes) throws IOException {
 		Vfs2NioPath p = toVFSPath(path);
 		FileObject fo = p.toFileObject();
-		
+
 		if (modes.length == 0) {
 			modes = new AccessMode[] { AccessMode.READ };
 		}
-		
+
 		for (AccessMode m : modes) {
 			switch (m) {
 			case EXECUTE:
@@ -222,7 +222,6 @@ public class Vfs2NioFileSystemProvider extends FileSystemProvider {
 		RandomAccessContent content = fileObject.getContent().getRandomAccessContent(accessMode);
 
 		return new FileChannelFromSeekableByteChannelImpl(new Vfs2NioSeekableByteChannel(content));
-		// return new Vfs2NioFileChannel(vfsPath, accessMode);
 	}
 
 	@Override

--- a/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileSystemProvider.java
+++ b/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileSystemProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2024 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileSystemProvider.java
+++ b/src/main/java/com/sshtools/vfs2nio/Vfs2NioFileSystemProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2018 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,9 @@ import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemManager;
 import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.RandomAccessContent;
 import org.apache.commons.vfs2.VFS;
+import org.apache.commons.vfs2.util.RandomAccessMode;
 
 public class Vfs2NioFileSystemProvider extends FileSystemProvider {
 	public final static String FILE_SYSTEM_OPTIONS = "com.sshtools.vfs2nio.fileSystemOptions";
@@ -79,6 +81,11 @@ public class Vfs2NioFileSystemProvider extends FileSystemProvider {
 	public void checkAccess(Path path, AccessMode... modes) throws IOException {
 		Vfs2NioPath p = toVFSPath(path);
 		FileObject fo = p.toFileObject();
+		
+		if (modes.length == 0) {
+			modes = new AccessMode[] { AccessMode.READ };
+		}
+		
 		for (AccessMode m : modes) {
 			switch (m) {
 			case EXECUTE:
@@ -206,8 +213,16 @@ public class Vfs2NioFileSystemProvider extends FileSystemProvider {
 
 	@Override
 	public FileChannel newFileChannel(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs) throws IOException {
-		// TODO
-		throw new UnsupportedOperationException();
+		RandomAccessMode accessMode = options.contains(StandardOpenOption.WRITE)
+				? RandomAccessMode.READWRITE
+				: RandomAccessMode.READ;
+
+		Vfs2NioPath vfsPath = toVFSPath(path);
+		FileObject fileObject = vfsPath.toFileObject();
+		RandomAccessContent content = fileObject.getContent().getRandomAccessContent(accessMode);
+
+		return new FileChannelFromSeekableByteChannelImpl(new Vfs2NioSeekableByteChannel(content));
+		// return new Vfs2NioFileChannel(vfsPath, accessMode);
 	}
 
 	@Override

--- a/src/main/java/com/sshtools/vfs2nio/Vfs2NioPath.java
+++ b/src/main/java/com/sshtools/vfs2nio/Vfs2NioPath.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2018 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/sshtools/vfs2nio/Vfs2NioPath.java
+++ b/src/main/java/com/sshtools/vfs2nio/Vfs2NioPath.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2024 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/sshtools/vfs2nio/Vfs2NioSeekableByteChannel.java
+++ b/src/main/java/com/sshtools/vfs2nio/Vfs2NioSeekableByteChannel.java
@@ -35,7 +35,7 @@ public class Vfs2NioSeekableByteChannel
 	public Vfs2NioSeekableByteChannel(RandomAccessContent content) {
 		this(content, true);
 	}
-	
+
 	public Vfs2NioSeekableByteChannel(RandomAccessContent content, boolean isOpen) {
 		super();
 		this.content = content;

--- a/src/main/java/com/sshtools/vfs2nio/Vfs2NioSeekableByteChannel.java
+++ b/src/main/java/com/sshtools/vfs2nio/Vfs2NioSeekableByteChannel.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.sshtools.vfs2nio;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+import org.apache.commons.vfs2.RandomAccessContent;
+
+import com.fasterxml.jackson.core.io.DataOutputAsStream;
+
+public class Vfs2NioSeekableByteChannel
+	implements SeekableByteChannel
+{
+	protected RandomAccessContent content;
+	protected boolean isOpen;
+
+	public Vfs2NioSeekableByteChannel(RandomAccessContent content) {
+		this(content, true);
+	}
+	
+	public Vfs2NioSeekableByteChannel(RandomAccessContent content, boolean isOpen) {
+		super();
+		this.content = content;
+		this.isOpen = isOpen;
+	}
+
+	@Override
+	public boolean isOpen() {
+		return isOpen;
+	}
+
+	@Override
+	public void close() throws IOException {
+		content.close();
+		isOpen = false;
+	}
+
+	public ReadableByteChannel getReadChannel() throws IOException {
+		return Channels.newChannel(content.getInputStream());
+	}
+
+	public WritableByteChannel getWriteChannel() throws IOException {
+		/* DataOutputAsStream comes from jackson */
+		return Channels.newChannel(new DataOutputAsStream(content));
+	}
+
+	@Override
+	public int read(ByteBuffer dst) throws IOException {
+		return getReadChannel().read(dst);
+	}
+
+	@Override
+	public int write(ByteBuffer src) throws IOException {
+		return getWriteChannel().write(src);
+	}
+
+	@Override
+	public long position() throws IOException {
+		return content.getFilePointer();
+	}
+
+	@Override
+	public SeekableByteChannel position(long newPosition) throws IOException {
+		content.seek(newPosition);
+		return this;
+	}
+
+	@Override
+	public long size() throws IOException {
+		return content.length();
+	}
+
+	@Override
+	public SeekableByteChannel truncate(long size) throws IOException {
+		content.setLength(size);
+		return this;
+	}
+
+}

--- a/src/main/java/org/apache/nio/BasePath.java
+++ b/src/main/java/org/apache/nio/BasePath.java
@@ -333,16 +333,14 @@ public abstract class BasePath<T extends BasePath<T, FS, P>, FS extends BaseFile
 
     @Override
     public URI toUri() {
-    	URI fsUri = ((Vfs2NioFileSystem)getFileSystem()).getUri();
-    	
-    	String str = fsUri + "/" + names.stream().collect(Collectors.joining("/"));
-    	try {
-			return new URI(str);
-		} catch (URISyntaxException e) {
-			throw new RuntimeException(e);
-		}
-        // File file = toFile();
-        // return file.toURI();
+        URI fsUri = ((Vfs2NioFileSystem)getFileSystem()).getUri();
+
+        String str = fsUri + "/" + names.stream().collect(Collectors.joining("/"));
+        try {
+            return new URI(str);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/apache/nio/BasePath.java
+++ b/src/main/java/org/apache/nio/BasePath.java
@@ -21,6 +21,7 @@ package org.apache.nio;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.nio.file.ProviderMismatchException;
@@ -37,6 +38,9 @@ import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.sshtools.vfs2nio.Vfs2NioFileSystem;
 
 public abstract class BasePath<T extends BasePath<T, FS, P>, FS extends BaseFileSystem<T, P>, P extends FileSystemProvider> implements Path {
 
@@ -329,8 +333,16 @@ public abstract class BasePath<T extends BasePath<T, FS, P>, FS extends BaseFile
 
     @Override
     public URI toUri() {
-        File file = toFile();
-        return file.toURI();
+    	URI fsUri = ((Vfs2NioFileSystem)getFileSystem()).getUri();
+    	
+    	String str = fsUri + "/" + names.stream().collect(Collectors.joining("/"));
+    	try {
+			return new URI(str);
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(e);
+		}
+        // File file = toFile();
+        // return file.toURI();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/sshtools/vfs2nio/Vfs2NioFileSystemProviderTest.java
+++ b/src/test/java/com/sshtools/vfs2nio/Vfs2NioFileSystemProviderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2018 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/sshtools/vfs2nio/Vfs2NioFileSystemProviderTest.java
+++ b/src/test/java/com/sshtools/vfs2nio/Vfs2NioFileSystemProviderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2018 - 2021 SSHTOOLS Limited (support@sshtools.com)
+ * Copyright © 2018 - 2024 SSHTOOLS Limited (support@sshtools.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR contains fixes for #3 - the PR is a revision of #1  which I accidently messed up.

* Added basic implementation for Vfs2NioFileSystemProvider.newFileChannel
* Fixed path segment computation in Vfs2NioFileSystem.iterator
* Changed implementation of BasePath.toUri to return an informational URI composed of the file system URI and the path. The prior implementation would usually raise an NPE because it relied on `.toFile()`. The provided solution may yet be suboptimal as the resulting URI is not suitable for round trips with `Paths.get(uri)`.
* Bumped Apache VFS2 to the latest version
